### PR TITLE
Add support for Slack Incoming Webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,29 @@ This Action is perfect for running on demand via `workflow_dispatch` or regularl
 
 **You will need:**
 * A GitHub personal access token that can access the project board you are monitoring and write access to a repo to store data
-* A valid Slack App token so the Action can post to a channel.
-* The Slack App will need to be invited to the channel.
+* Slack Integration, one of following:
+  * Using Slack App
+    * Slack App token so the Action can post to a channel.
+    * The Slack App will need to be invited to the channel.
+  * Using Incoming Webhooks
+    * Slack App with Incoming Webhooks enabled.
+    * The Webhook for the channel.
+
+**Note: **
+
+*Incoming Webhooks make it easier to integrate Slack App into the Workspace but comes with limitation. Webhooks allow posting messages but does not allow updating existing messages. Feature used when `TRACK_ISSUES` is enabled and a GitHub issue comment was updated after related Slack message was posted.*
 
 **Inputs:**
 * `PAT`: A GitHub personal access token with the required access.
-* `SLACK_TOKEN`: A Slack token for a Slack App.
-* `PROJECT_URL`: A URL to the project that you'd like to track.
+* `SLACK_TOKEN`: A Slack token for a Slack App. It is possible to use SLACK_WEBHOOK instead.
 * `CHANNEL`: A channel to post notifications too.
+* `SLACK_WEBHOOK`: An Incoming Webhook for Slack. Does not allow updating slack messages.
+* `PROJECT_URL`: A URL to the project that you'd like to track.
 * `REPO_FOR_DATA`: A repository to store data to. It will be stored in a `.data` directory.
 * `TRACK_ISSUES` (optional): `true` if you'd like to be notified about comments on issues
 * `LABELS` (optional): a list of labels that you'd like to track.
 
-**Example YML:**
+**Examples YML:**
 
 ```yaml
 name: Test
@@ -47,6 +57,23 @@ jobs:
           SLACK_TOKEN: ${{ secrets.SLACK_TOKEN }}
           PROJECT_URL: "https://github.com/orgs/your-cool-org/projects/1"
           CHANNEL: "#your-cool-project-channel"
+          REPO_FOR_DATA: "andymckay/data"
+```
+
+```yaml
+name: Test
+on:
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/project-slack-notification@main
+        with:
+          PAT: ${{ secrets.PAT }}
+          SLACK_WEBHOOK: ${{ secrets.MY_CHANNEL_WEBHOOK }}
+          PROJECT_URL: "https://github.com/orgs/your-cool-org/projects/1"
           REPO_FOR_DATA: "andymckay/data"
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -8,14 +8,17 @@ inputs:
     description: "A personal access token for GitHub"
     required: true
   SLACK_TOKEN:
-    description: "A token for Slack"
-    required: true
+    description: "A token for Slack. It is possible to use SLACK_WEBHOOK instead."
+    required: false
+  SLACK_WEBHOOK:
+    description: "An Incoming Webhook for Slack. Does not allow updating slack messages."
+    required: false
   PROJECT_URL:
     description: "The URL for the project"
     required: true
   CHANNEL:
-    description: "The Slack channel to post to"
-    required: true
+    description: "The Slack channel to post to. Required if SLACK_TOKEN was specified."
+    required: false
   REPO_FOR_DATA:
     description: "The repo for data in org/repo format."
     required: true


### PR DESCRIPTION
Since integrating Slack App with `chat:write` into workspace could be challenging due to organisation policies, this commit introduces alternative way of posting messages using Incoming Webhooks. This approach comes with limitation, since webhooks don't allow updating already posted messages.